### PR TITLE
Some fixes for my use case

### DIFF
--- a/neovim-remote.go
+++ b/neovim-remote.go
@@ -48,12 +48,21 @@ neovim-remote
 		os.Exit(0)
 	}
 
+	var servernameEnv string
+
+	nvimEnv := os.Getenv("NVIM")
+	if nvimEnv != "" {
+		servernameEnv = nvimEnv
+	} else {
+		servernameEnv = os.Getenv("NVIM_LISTEN_ADDRESS")
+	}
+
 	option := option{
 		noStart:    noStart,
 		remoteWait: remoteWait,
 		remoteSend: remoteSend,
 		remoteExpr: remoteExpr,
-		servername: os.Getenv("NVIM_LISTEN_ADDRESS"),
+		servername: servernameEnv,
 		beforeExec: cc,
 		afterExec:  c,
 	}

--- a/neovim-remote.go
+++ b/neovim-remote.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -90,10 +91,19 @@ neovim-remote
 }
 
 func NewRunner(files []string, out io.Writer, option option, debug bool) (*runner, error) {
+	absFiles := make([]string, len(files))
+	for i, file := range files {
+		absPath, err := filepath.Abs(file)
+		if err != nil {
+			fmt.Errorf("failed to find file %s: %w", file, err)
+		}
+		absFiles[i] = absPath
+	}
+
 	return &runner{
 		out:       out,
 		option:    option,
-		files:     files,
+		files:     absFiles,
 		waitCount: 0,
 		debug:     debug,
 	}, nil


### PR DESCRIPTION
I mainly use neovim-remote to edit files from [lazygit.nvim](https://github.com/kdheepak/lazygit.nvim). It opens a popup window, so `edit` doesn't work well for me (it will open the file directly in that window, but the buffer is still controlled by neovim main window). Also, when I switch to one file, neovim changes it's working directory, so I can't open another file with this tool.

These changes don't affect the default behavior of this program, at least I'm not intended to do so.

Also I've not learned golang and I wrote it by guessing It's meaning, so these changes may not be the best approach.